### PR TITLE
Added descriptionKey for TextField component

### DIFF
--- a/cdi-properties-generator/src/main/java/org/vaadin/addon/cdiproperties/Generator.java
+++ b/cdi-properties-generator/src/main/java/org/vaadin/addon/cdiproperties/Generator.java
@@ -44,8 +44,6 @@ class Generator {
             Long.class, Float.class, Double.class);
 
     public static void main(String[] args) {
-        Locale.setDefault(Locale.ENGLISH);
-
         Set<ComponentModel> componentModels = Sets.newHashSet();
 
         for (PojoClass pojoClass : PojoClassFactory

--- a/cdi-properties-generator/src/main/java/org/vaadin/addon/cdiproperties/Generator.java
+++ b/cdi-properties-generator/src/main/java/org/vaadin/addon/cdiproperties/Generator.java
@@ -8,9 +8,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
-
-import org.vaadin.addon.cdiproperties.Generator.ComponentModel.ComponentProperty;
 
 import com.google.gwt.thirdparty.guava.common.collect.Lists;
 import com.google.gwt.thirdparty.guava.common.collect.Sets;
@@ -25,9 +24,11 @@ import com.vaadin.ui.GridLayout;
 import com.vaadin.ui.Label;
 import com.vaadin.ui.LegacyWindow;
 import com.vaadin.ui.LoginForm;
+import com.vaadin.ui.TextField;
 import com.vaadin.ui.components.colorpicker.ColorPickerGrid;
 import com.vaadin.ui.components.colorpicker.ColorPickerHistory;
 import com.vaadin.ui.components.colorpicker.ColorPickerSelect;
+import org.vaadin.addon.cdiproperties.Generator.ComponentModel.ComponentProperty;
 
 class Generator {
 
@@ -37,12 +38,13 @@ class Generator {
                     LoginForm.class);
     private static Set<String> excludedProperties = Sets.newHashSet("UI",
             "componentError", "connectorEnabled", "connectorId", "width",
-            "height", "stateType", "type", "styleName");
+            "height", "stateType", "type", "styleName", "timeFormat");
     private static Set primitiveWrapperClasses = Sets.newHashSet(Boolean.class,
             Byte.class, Character.class, Short.class, Integer.class,
             Long.class, Float.class, Double.class);
 
     public static void main(String[] args) {
+        Locale.setDefault(Locale.ENGLISH);
 
         Set<ComponentModel> componentModels = Sets.newHashSet();
 
@@ -169,6 +171,12 @@ class Generator {
             result.add(new ComponentProperty("String", "valueKey",
                     "org.vaadin.addon.cdiproperties.ComponentConfigurator.IGNORED_STRING"));
         }
+
+        if (implementation instanceof TextField) {
+            result.add(new ComponentProperty("String", "descriptionKey",
+                    "org.vaadin.addon.cdiproperties.ComponentConfigurator.IGNORED_STRING"));
+        }
+
         return result;
     }
 
@@ -189,7 +197,10 @@ class Generator {
 
     static String formatDefaultValue(Object defaultValue) {
         String result = String.valueOf(defaultValue);
-        if (defaultValue instanceof String) {
+
+        if (defaultValue instanceof Boolean) {
+            result = defaultValue.toString();
+        } else if (defaultValue instanceof String) {
             result = "\"" + defaultValue + "\"";
         } else if (defaultValue instanceof Float) {
             result = result.concat("f");

--- a/cdi-properties-generator/src/main/java/org/vaadin/addon/cdiproperties/Generator.java
+++ b/cdi-properties-generator/src/main/java/org/vaadin/addon/cdiproperties/Generator.java
@@ -8,7 +8,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Locale;
 import java.util.Set;
 
 import com.google.gwt.thirdparty.guava.common.collect.Lists;
@@ -44,6 +43,7 @@ class Generator {
             Long.class, Float.class, Double.class);
 
     public static void main(String[] args) {
+
         Set<ComponentModel> componentModels = Sets.newHashSet();
 
         for (PojoClass pojoClass : PojoClassFactory
@@ -195,10 +195,7 @@ class Generator {
 
     static String formatDefaultValue(Object defaultValue) {
         String result = String.valueOf(defaultValue);
-
-        if (defaultValue instanceof Boolean) {
-            result = defaultValue.toString();
-        } else if (defaultValue instanceof String) {
+        if (defaultValue instanceof String) {
             result = "\"" + defaultValue + "\"";
         } else if (defaultValue instanceof Float) {
             result = result.concat("f");

--- a/cdi-properties/pom.xml
+++ b/cdi-properties/pom.xml
@@ -16,7 +16,7 @@
 		<dependency>
 			<groupId>com.vaadin</groupId>
 			<artifactId>vaadin-cdi</artifactId>
-			<version>1.0.0.alpha1</version>
+			<version>1.0.2</version>
 		</dependency>
 		<dependency>
 			<groupId>javax.enterprise</groupId>
@@ -106,7 +106,6 @@
 						<configuration>
 							<classpathScope>compile</classpathScope>
 							<mainClass>org.vaadin.addon.cdiproperties.Generator</mainClass>
-							<workingDirectory>${project.basedir}</workingDirectory>
 							<arguments>
 								<argument>${annotation.package}</argument>
 								<argument>${producer.package}</argument>

--- a/cdi-properties/src/main/java/org/vaadin/addon/cdiproperties/ComponentConfigurator.java
+++ b/cdi-properties/src/main/java/org/vaadin/addon/cdiproperties/ComponentConfigurator.java
@@ -202,9 +202,8 @@ public class ComponentConfigurator implements Serializable {
                 try {
                     field.setDescription(textBundle.get().getText(descriptionKey));
                     if (localized) {
-                        localizer.get().addLocalizedCaption(component,
+                        localizer.get().addLocalizedDescription(field,
                                                             descriptionKey);
-
                     }
                 } catch (final UnsatisfiedResolutionException e) {
                     field.setDescription("No TextBundle implementation found!");

--- a/cdi-properties/src/main/java/org/vaadin/addon/cdiproperties/ComponentConfigurator.java
+++ b/cdi-properties/src/main/java/org/vaadin/addon/cdiproperties/ComponentConfigurator.java
@@ -19,7 +19,7 @@ import com.vaadin.ui.AbstractOrderedLayout;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.GridLayout;
 import com.vaadin.ui.Label;
-import com.vaadin.ui.TextField;
+import com.vaadin.ui.AbstractComponent;
 
 
 @SuppressWarnings("serial")
@@ -198,7 +198,7 @@ public class ComponentConfigurator implements Serializable {
             final Boolean localized = (Boolean) getPropertyValue(
                     propertyAnnotation, "localized");
             if (!IGNORED_STRING.equals(descriptionKey)) {
-                TextField field = (TextField) component;
+                AbstractComponent field = (AbstractComponent) component;
                 try {
                     field.setDescription(textBundle.get().getText(descriptionKey));
                     if (localized) {
@@ -214,7 +214,7 @@ public class ComponentConfigurator implements Serializable {
 
         @Override
         boolean appliesTo(Component component) {
-            return (component instanceof TextField);
+            return (component instanceof AbstractComponent);
         }
     }
 

--- a/cdi-properties/src/main/java/org/vaadin/addon/cdiproperties/ComponentConfigurator.java
+++ b/cdi-properties/src/main/java/org/vaadin/addon/cdiproperties/ComponentConfigurator.java
@@ -19,6 +19,8 @@ import com.vaadin.ui.AbstractOrderedLayout;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.GridLayout;
 import com.vaadin.ui.Label;
+import com.vaadin.ui.TextField;
+
 
 @SuppressWarnings("serial")
 @SessionScoped
@@ -196,15 +198,16 @@ public class ComponentConfigurator implements Serializable {
             final Boolean localized = (Boolean) getPropertyValue(
                     propertyAnnotation, "localized");
             if (!IGNORED_STRING.equals(descriptionKey)) {
+                TextField field = (TextField) component;
                 try {
-                    component.setCaption(textBundle.get().getText(descriptionKey));
+                    field.setDescription(textBundle.get().getText(descriptionKey));
                     if (localized) {
                         localizer.get().addLocalizedCaption(component,
                                                             descriptionKey);
 
                     }
                 } catch (final UnsatisfiedResolutionException e) {
-                    component.setCaption("No TextBundle implementation found!");
+                    field.setDescription("No TextBundle implementation found!");
                 }
 
             }
@@ -212,7 +215,7 @@ public class ComponentConfigurator implements Serializable {
 
         @Override
         boolean appliesTo(Component component) {
-            return true;
+            return (component instanceof TextField);
         }
     }
 

--- a/cdi-properties/src/main/java/org/vaadin/addon/cdiproperties/ComponentConfigurator.java
+++ b/cdi-properties/src/main/java/org/vaadin/addon/cdiproperties/ComponentConfigurator.java
@@ -183,6 +183,39 @@ public class ComponentConfigurator implements Serializable {
         }
     }
 
+    private static class CustomPropertyDescriptionKey extends CustomProperty {
+        @Inject
+        private Instance<TextBundle> textBundle;
+        @Inject
+        private Instance<Localizer> localizer;
+
+        @Override
+        void apply(Component component, Annotation propertyAnnotation) {
+            final String descriptionKey = (String) getPropertyValue(
+                    propertyAnnotation, "descriptionKey");
+            final Boolean localized = (Boolean) getPropertyValue(
+                    propertyAnnotation, "localized");
+            if (!IGNORED_STRING.equals(descriptionKey)) {
+                try {
+                    component.setCaption(textBundle.get().getText(descriptionKey));
+                    if (localized) {
+                        localizer.get().addLocalizedCaption(component,
+                                                            descriptionKey);
+
+                    }
+                } catch (final UnsatisfiedResolutionException e) {
+                    component.setCaption("No TextBundle implementation found!");
+                }
+
+            }
+        }
+
+        @Override
+        boolean appliesTo(Component component) {
+            return true;
+        }
+    }
+
     private static class CustomPropertyMargin extends CustomProperty {
         @Override
         void apply(Component component, Annotation propertyAnnotation) {

--- a/cdi-properties/src/main/java/org/vaadin/addon/cdiproperties/Localizer.java
+++ b/cdi-properties/src/main/java/org/vaadin/addon/cdiproperties/Localizer.java
@@ -18,6 +18,7 @@ import javax.inject.Qualifier;
 import com.vaadin.cdi.UIScoped;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.Label;
+import com.vaadin.ui.TextField;
 
 @SuppressWarnings("serial")
 @UIScoped
@@ -28,6 +29,7 @@ public class Localizer implements Serializable {
 
     private final Map<Component, String> localizedCaptions = new HashMap<Component, String>();
     private final Map<Label, String> localizedLabelValues = new HashMap<Label, String>();
+    private final Map<TextField, String> localizedDescriptions = new HashMap<TextField, String>();
 
     void updateCaption(@Observes @TextBundleUpdated final Object parameters) {
         for (final Entry<Component, String> entry : localizedCaptions
@@ -50,6 +52,16 @@ public class Localizer implements Serializable {
                         .setCaption("No TextBundle implementation found!");
             }
         }
+
+        for (final Entry<TextField, String> entry : localizedDescriptions.entrySet()) {
+            try {
+                entry.getKey().setValue(
+                        textBundle.get().gettext(entry.getValue()));
+            } catch (final UnsatisfiedResolutionException e) {
+                entry.getKey()
+                        .setDescription("No TextBundle implementation found!");
+            }
+        }
     }
 
     void addLocalizedCaption(final Component component, final String captionKey) {
@@ -58,6 +70,10 @@ public class Localizer implements Serializable {
 
     void addLocalizedLabelValue(final Label label, final String labelValueKey) {
         localizedLabelValues.put(label, labelValueKey);
+    }
+
+    void addLocalizedDescription(final TextField field, final String descriptionKey) {
+        localizedDescriptions.put(field, descriptionKey);
     }
 
     @Qualifier

--- a/cdi-properties/src/main/java/org/vaadin/addon/cdiproperties/Localizer.java
+++ b/cdi-properties/src/main/java/org/vaadin/addon/cdiproperties/Localizer.java
@@ -55,7 +55,7 @@ public class Localizer implements Serializable {
 
         for (final Entry<AbstractComponent, String> entry : localizedDescriptions.entrySet()) {
             try {
-                entry.getKey().setValue(
+                entry.getKey().setDescription(
                         textBundle.get().getText(entry.getValue()));
             } catch (final UnsatisfiedResolutionException e) {
                 entry.getKey()

--- a/cdi-properties/src/main/java/org/vaadin/addon/cdiproperties/Localizer.java
+++ b/cdi-properties/src/main/java/org/vaadin/addon/cdiproperties/Localizer.java
@@ -18,7 +18,7 @@ import javax.inject.Qualifier;
 import com.vaadin.cdi.UIScoped;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.Label;
-import com.vaadin.ui.TextField;
+import com.vaadin.ui.AbstractComponent;
 
 @SuppressWarnings("serial")
 @UIScoped
@@ -29,7 +29,7 @@ public class Localizer implements Serializable {
 
     private final Map<Component, String> localizedCaptions = new HashMap<Component, String>();
     private final Map<Label, String> localizedLabelValues = new HashMap<Label, String>();
-    private final Map<TextField, String> localizedDescriptions = new HashMap<TextField, String>();
+    private final Map<AbstractComponent, String> localizedDescriptions = new HashMap<AbstractComponent, String>();
 
     void updateCaption(@Observes @TextBundleUpdated final Object parameters) {
         for (final Entry<Component, String> entry : localizedCaptions
@@ -53,10 +53,10 @@ public class Localizer implements Serializable {
             }
         }
 
-        for (final Entry<TextField, String> entry : localizedDescriptions.entrySet()) {
+        for (final Entry<AbstractComponent, String> entry : localizedDescriptions.entrySet()) {
             try {
                 entry.getKey().setValue(
-                        textBundle.get().gettext(entry.getValue()));
+                        textBundle.get().getText(entry.getValue()));
             } catch (final UnsatisfiedResolutionException e) {
                 entry.getKey()
                         .setDescription("No TextBundle implementation found!");
@@ -72,7 +72,7 @@ public class Localizer implements Serializable {
         localizedLabelValues.put(label, labelValueKey);
     }
 
-    void addLocalizedDescription(final TextField field, final String descriptionKey) {
+    void addLocalizedDescription(final AbstractComponent field, final String descriptionKey) {
         localizedDescriptions.put(field, descriptionKey);
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 		<dependency>
 			<groupId>com.vaadin</groupId>
 			<artifactId>vaadin-cdi</artifactId>
-			<version>1.0.0.alpha1</version>
+			<version>1.0.2</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
The TextField component was missing the descriptionKey to be able to add a localized description to the text field.

In addition vaadin-cdi is now available in version 1.0.2 so I updated the dependency. The TimeFormat property (which seems to be new) is breaking the Generator. So I excluded it from generation.