### PR TITLE
Update to Vaadin 8.0

### DIFF
--- a/cdi-properties-generator/pom.xml
+++ b/cdi-properties-generator/pom.xml
@@ -34,8 +34,8 @@
 					<artifactId>maven-compiler-plugin</artifactId>
 					<version>2.3.2</version>
 					<configuration>
-						<source>1.6</source>
-						<target>1.6</target>
+						<source>1.8</source>
+						<target>1.8</target>
 					</configuration>
 				</plugin>
 				<!--This plugin's configuration is used to store Eclipse m2e settings 

--- a/cdi-properties-generator/pom.xml
+++ b/cdi-properties-generator/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.vaadin.addon</groupId>
 		<artifactId>cdi-properties-parent</artifactId>
-		<version>0.9.3</version>
+		<version>0.10.0</version>
 	</parent>
 
 	<artifactId>cdi-properties-generator</artifactId>

--- a/cdi-properties-generator/src/main/java/org/vaadin/addon/cdiproperties/Generator.java
+++ b/cdi-properties-generator/src/main/java/org/vaadin/addon/cdiproperties/Generator.java
@@ -77,10 +77,7 @@ class Generator {
                 Object implementation = getPojoInstance(pojoClass);
 
                 if (implementation != null) {
-                    ComponentModel componentModel = new ComponentModel(
-                            pojoClass.getClazz());
-
-                    Method[] pojoMethods = pojoClass.getClazz().getMethods();
+                    ComponentModel componentModel = new ComponentModel(pojoClass.getClazz());
 
                     // Add bean properties
                     BeanInfo bi = Introspector.getBeanInfo(implementation.getClass());

--- a/cdi-properties/pom.xml
+++ b/cdi-properties/pom.xml
@@ -7,8 +7,8 @@
 	<version>0.10.0</version>
 
 	<properties>
-		<annotation.package>${project.build.directory}/generated-sources/src/main/java/org/vaadin/addon/cdiproperties/annotation</annotation.package>
-		<producer.package>${project.build.directory}/generated-sources/src/main/java/org/vaadin/addon/cdiproperties/producer</producer.package>
+		<annotation.package>${project.build.directory}/generated-sources/cdi-properties/org/vaadin/addon/cdiproperties/annotation</annotation.package>
+		<producer.package>${project.build.directory}/generated-sources/cdi-properties/org/vaadin/addon/cdiproperties/producer</producer.package>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 	
@@ -39,8 +39,8 @@
 		</dependency>
 		<dependency>
 			<groupId>javax.servlet</groupId>
-			<artifactId>servlet-api</artifactId>
-			<version>2.5</version>
+			<artifactId>javax.servlet-api</artifactId>
+			<version>3.0.1</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
@@ -117,7 +117,7 @@
 								<argument>${annotation.package}</argument>
 								<argument>${producer.package}</argument>
 							</arguments>
-							<sourceRoot>${project.build.directory}/generated-sources/src/main/java/</sourceRoot>
+							<sourceRoot>${project.build.directory}/generated-sources/cdi-properties/</sourceRoot>
 						</configuration>
 						<goals>
 							<goal>java</goal>
@@ -134,8 +134,8 @@
 					<artifactId>maven-compiler-plugin</artifactId>
 					<version>2.3.2</version>
 					<configuration>
-						<source>1.6</source>
-						<target>1.6</target>
+						<source>1.8</source>
+						<target>1.8</target>
 					</configuration>
 
 				</plugin>

--- a/cdi-properties/pom.xml
+++ b/cdi-properties/pom.xml
@@ -16,7 +16,7 @@
 		<dependency>
 			<groupId>com.vaadin</groupId>
 			<artifactId>vaadin-cdi</artifactId>
-			<version>1.0.2</version>
+			<version>2.0.0</version>
 		</dependency>
 		<dependency>
 			<groupId>javax.enterprise</groupId>

--- a/cdi-properties/pom.xml
+++ b/cdi-properties/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.vaadin.addon</groupId>
 	<artifactId>cdi-properties</artifactId>
-	<version>0.9.3</version>
+	<version>0.10.0</version>
 
 	<properties>
 		<annotation.package>${project.build.directory}/generated-sources/src/main/java/org/vaadin/addon/cdiproperties/annotation</annotation.package>
@@ -46,8 +46,8 @@
 		<dependency>
 			<groupId>org.vaadin.addon</groupId>
 			<artifactId>cdi-properties-generator</artifactId>
-			<version>0.9.3</version>
-			<scope>provided</scope>
+			<version>0.10.0</version>
+			<scope>compile</scope>
 		</dependency>
 	</dependencies>
 

--- a/cdi-properties/pom.xml
+++ b/cdi-properties/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.vaadin.addon</groupId>
 	<artifactId>cdi-properties</artifactId>
@@ -47,6 +47,7 @@
 			<groupId>org.vaadin.addon</groupId>
 			<artifactId>cdi-properties-generator</artifactId>
 			<version>0.10.0</version>
+			<optional>true</optional>
 			<scope>compile</scope>
 		</dependency>
 	</dependencies>

--- a/cdi-properties/src/main/java/org/vaadin/addon/cdiproperties/ComponentConfigurator.java
+++ b/cdi-properties/src/main/java/org/vaadin/addon/cdiproperties/ComponentConfigurator.java
@@ -202,9 +202,8 @@ public class ComponentConfigurator implements Serializable {
                 try {
                     field.setDescription(textBundle.get().getText(descriptionKey));
                     if (localized) {
-                        localizer.get().addLocalizedCaption(component,
+                        localizer.get().addLocalizedDescription(field,
                                                             descriptionKey);
-
                     }
                 } catch (final UnsatisfiedResolutionException e) {
                     field.setDescription("No TextBundle implementation found!");

--- a/cdi-properties/src/main/java/org/vaadin/addon/cdiproperties/ComponentConfigurator.java
+++ b/cdi-properties/src/main/java/org/vaadin/addon/cdiproperties/ComponentConfigurator.java
@@ -19,7 +19,7 @@ import com.vaadin.ui.AbstractOrderedLayout;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.GridLayout;
 import com.vaadin.ui.Label;
-import com.vaadin.ui.TextField;
+import com.vaadin.ui.AbstractComponent;
 
 
 @SuppressWarnings("serial")
@@ -198,7 +198,7 @@ public class ComponentConfigurator implements Serializable {
             final Boolean localized = (Boolean) getPropertyValue(
                     propertyAnnotation, "localized");
             if (!IGNORED_STRING.equals(descriptionKey)) {
-                TextField field = (TextField) component;
+                AbstractComponent field = (AbstractComponent) component;
                 try {
                     field.setDescription(textBundle.get().getText(descriptionKey));
                     if (localized) {
@@ -214,7 +214,7 @@ public class ComponentConfigurator implements Serializable {
 
         @Override
         boolean appliesTo(Component component) {
-            return (component instanceof TextField);
+            return (component instanceof AbstractComponent);
         }
     }
 

--- a/cdi-properties/src/main/java/org/vaadin/addon/cdiproperties/Localizer.java
+++ b/cdi-properties/src/main/java/org/vaadin/addon/cdiproperties/Localizer.java
@@ -18,6 +18,7 @@ import javax.inject.Qualifier;
 import com.vaadin.cdi.UIScoped;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.Label;
+import com.vaadin.ui.TextField;
 
 @SuppressWarnings("serial")
 @UIScoped
@@ -28,6 +29,7 @@ public class Localizer implements Serializable {
 
     private final Map<Component, String> localizedCaptions = new HashMap<Component, String>();
     private final Map<Label, String> localizedLabelValues = new HashMap<Label, String>();
+    private final Map<TextField, String> localizedDescriptions = new HashMap<TextField, String>();
 
     void updateCaption(@Observes @TextBundleUpdated final Object parameters) {
         for (final Entry<Component, String> entry : localizedCaptions
@@ -50,6 +52,16 @@ public class Localizer implements Serializable {
                         .setCaption("No TextBundle implementation found!");
             }
         }
+
+        for (final Entry<TextField, String> entry : localizedDescriptions.entrySet()) {
+            try {
+                entry.getKey().setValue(
+                        textBundle.get().gettext(entry.getValue()));
+            } catch (final UnsatisfiedResolutionException e) {
+                entry.getKey()
+                        .setDescription("No TextBundle implementation found!");
+            }
+        }
     }
 
     void addLocalizedCaption(final Component component, final String captionKey) {
@@ -58,6 +70,10 @@ public class Localizer implements Serializable {
 
     void addLocalizedLabelValue(final Label label, final String labelValueKey) {
         localizedLabelValues.put(label, labelValueKey);
+    }
+
+    void addLocalizedDescription(final TextField field, final String descriptionKey) {
+        localizedDescriptions.put(field, descriptionKey);
     }
 
     @Qualifier

--- a/cdi-properties/src/main/java/org/vaadin/addon/cdiproperties/Localizer.java
+++ b/cdi-properties/src/main/java/org/vaadin/addon/cdiproperties/Localizer.java
@@ -55,7 +55,7 @@ public class Localizer implements Serializable {
 
         for (final Entry<AbstractComponent, String> entry : localizedDescriptions.entrySet()) {
             try {
-                entry.getKey().setValue(
+                entry.getKey().setDescription(
                         textBundle.get().getText(entry.getValue()));
             } catch (final UnsatisfiedResolutionException e) {
                 entry.getKey()

--- a/cdi-properties/src/main/java/org/vaadin/addon/cdiproperties/Localizer.java
+++ b/cdi-properties/src/main/java/org/vaadin/addon/cdiproperties/Localizer.java
@@ -18,7 +18,7 @@ import javax.inject.Qualifier;
 import com.vaadin.cdi.UIScoped;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.Label;
-import com.vaadin.ui.TextField;
+import com.vaadin.ui.AbstractComponent;
 
 @SuppressWarnings("serial")
 @UIScoped
@@ -29,7 +29,7 @@ public class Localizer implements Serializable {
 
     private final Map<Component, String> localizedCaptions = new HashMap<Component, String>();
     private final Map<Label, String> localizedLabelValues = new HashMap<Label, String>();
-    private final Map<TextField, String> localizedDescriptions = new HashMap<TextField, String>();
+    private final Map<AbstractComponent, String> localizedDescriptions = new HashMap<AbstractComponent, String>();
 
     void updateCaption(@Observes @TextBundleUpdated final Object parameters) {
         for (final Entry<Component, String> entry : localizedCaptions
@@ -53,10 +53,10 @@ public class Localizer implements Serializable {
             }
         }
 
-        for (final Entry<TextField, String> entry : localizedDescriptions.entrySet()) {
+        for (final Entry<AbstractComponent, String> entry : localizedDescriptions.entrySet()) {
             try {
                 entry.getKey().setValue(
-                        textBundle.get().gettext(entry.getValue()));
+                        textBundle.get().getText(entry.getValue()));
             } catch (final UnsatisfiedResolutionException e) {
                 entry.getKey()
                         .setDescription("No TextBundle implementation found!");
@@ -72,7 +72,7 @@ public class Localizer implements Serializable {
         localizedLabelValues.put(label, labelValueKey);
     }
 
-    void addLocalizedDescription(final TextField field, final String descriptionKey) {
+    void addLocalizedDescription(final AbstractComponent field, final String descriptionKey) {
         localizedDescriptions.put(field, descriptionKey);
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 		<dependency>
 			<groupId>com.vaadin</groupId>
 			<artifactId>vaadin-cdi</artifactId>
-			<version>1.0.2</version>
+			<version>2.0.0</version>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.vaadin.addon</groupId>
 	<artifactId>cdi-properties-parent</artifactId>
-	<version>0.9.3</version>
+	<version>0.10.0</version>
 	<packaging>pom</packaging>
 
 	<modules>


### PR DESCRIPTION
I updated the cdi-properties to Vaadin 8.0 (and tested them very shortly with a single app with textfield and button).

I bumped version to 0.10.0 to show that something big changed. In addition I changed compiler settings to Java 1.8 instead of 1.6 (Java 8 is needed for Vaadin  nevertheless).

Since guava is not included any more I replaced the calls to newHashSet and newArrayList with small local classes within the generator to not include another dependency. But that's only a small option, could depend on google guave instead, of course.

The last change is that I use java reflection API directly instead of the BeanItem that is not there any more.

Please say, if you don't like something, but I like the injection of components too much to not having it with Vaadin 8 :-)